### PR TITLE
fix: Cerbos version detection that works on all OSes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,16 @@ cerbos-binary:
 	@ if [[ "$$CERBOS_RELEASE" ]]; then \
 		CURRENT_RELEASE=$$CERBOS_RELEASE; \
 	else \
-		CURRENT_RELEASE=$$(curl -sH "Accept: application/vnd.github.v3+json"  https://api.github.com/repos/cerbos/cerbos/tags | grep -o -E '"name": "v\d+\.\d+.\d+"' | head -1); \
+		CURRENT_RELEASE=$$(curl -sH "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/cerbos/cerbos/tags?per_page=1" | jq -r '.[].name | ltrimstr("v")'); \
 	fi; \
 	ver='[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'; \
 	if [[ $$CURRENT_RELEASE =~ $$ver  ]]; then \
 		CURRENT_RELEASE="$${BASH_REMATCH[0]}"; \
 	else \
-		echo "Unexpected format of CERBOS_RELEASE, expected semantic version 'x.x.x'" >&2; \
+		echo "Unexpected format of CERBOS_RELEASE ($$CURRENT_RELEASE), expected semantic version 'x.x.x'" >&2; \
 		exit 1; \
 	fi; \
+	echo "Using Cerbos $$CURRENT_RELEASE"
 	arch=$$(uname -m); [ "$$arch" != "x86_64" ] && [ "$$arch" != "arm64" ] && { echo "$${arch} - unsupported architecture, supported: x86_64, arm64" >&2; exit 1; }; \
 	oses=(Linux); \
 	if [[ $$(uname -s) = Darwin ]]; then \

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ The following tools are required:
 - AWS CLI
 - AWS SAM CLI - if you wish to use the provided AWS Lambda function template
 - Docker
+- jq - If you want the Makefile to automatically detect the version of Cerbos. Otherwise use the `CERBOS_RELEASE` environment variable to specify the Cerbos version to use.
+
 
 ### Build the Docker image
 
-Check out `conf.default.yml` for Cerbos configuration. The default configuration uses blob storage, e.g. AWS S3 bucket. Cerbos config can read from environment variables. If you choose to do so, your AWS Lambda has to expose them. 
+Check out `conf.default.yml` for Cerbos configuration. The default configuration uses blob storage, e.g. AWS S3 bucket. Cerbos config can read from environment variables. If you choose to do so, your AWS Lambda has to expose them.
 
 By default, the latest release of Cerbos is used. If you want to use a particular Cerbos version, you can specify it in `CERBOS_RELEASE` environment variable.
 


### PR DESCRIPTION
Using `jq` here because it's now pretty much a standard tool. Those who
don't have it can use the escape hatch of manually specifying the Cerbos
version (`CERBOS_RELEASE=0.25.0 make image`).

Fixes #6

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
